### PR TITLE
Adding run method call for prompt-toolkit radiolist_dialog module, wh…

### DIFF
--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -67,7 +67,7 @@ def set_time_zone():
     # Ask user to select time zone from list.
     return radiolist_dialog(
         values=time_zone, title="Time Zone", text="Please select assessment time zone:"
-    )
+    ).run()
 
 
 def display_list_groups(assessment):

--- a/tests/test_assessment_builder.py
+++ b/tests/test_assessment_builder.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env pytest -vs
+"""Test for Assessment Builder."""
+# Third-Party Libraries
+from mock import patch
+
+# cisagov Libraries
+from assessment.builder import set_time_zone
+
+
+class TestSetTimezone:
+    """Test setting timezone logic."""
+
+    def test_radiolist_dialog_run_callsed(self):
+        """Verify radiolist_dialog run called once."""
+        with patch("assessment.builder.radiolist_dialog") as run_patch:
+            set_time_zone()
+            run_patch().run.assert_called_once()

--- a/tests/test_assessment_builder.py
+++ b/tests/test_assessment_builder.py
@@ -10,7 +10,7 @@ from assessment.builder import set_time_zone
 class TestSetTimezone:
     """Test setting timezone logic."""
 
-    def test_radiolist_dialog_run_callsed(self):
+    def test_radiolist_dialog_run_called(self):
         """Verify radiolist_dialog run called once."""
         with patch("assessment.builder.radiolist_dialog") as run_patch:
             set_time_zone()


### PR DESCRIPTION
…ich is required in newer version

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Fixes the timezone selection prompt issue.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Resolves #37. The prompt was not displaying before due to a missing method call to .run() which is apparently required in the new version of the prompt_toolkit radiolist_dialog module
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
1. Drop into COOL env (or build and tag image locally)
2. Try running docker run -it cisagov/gophish-tools pca-wizard "RV1234_test" (the prompt should now trigger - see screenshot)<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

![Screen Shot 2021-07-21 at 3 49 40 PM](https://user-images.githubusercontent.com/6486652/126560524-cc649c0a-2516-4e8a-8243-7da0ae3ec361.png)


<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
