### PR TITLE
Logging format cstring cleanup

### DIFF
--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.7"
+__version__ = "0.0.7-rc.1"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.6"
+__version__ = "0.0.7"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.7-rc.2"
+__version__ = "0.0.7"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.7-rc.1"
+__version__ = "0.0.7-rc.2"

--- a/src/tools/gophish_cleaner.py
+++ b/src/tools/gophish_cleaner.py
@@ -159,7 +159,7 @@ def main() -> None:
         )
     except ValueError:
         logging.critical(
-            '"%s"is not a valid logging level.  Possible values are debug, info, warning, and error.',
+            '"%s" is not a valid logging level.  Possible values are debug, info, warning, and error.',
             log_level,
         )
         sys.exit(1)

--- a/src/tools/gophish_cleaner.py
+++ b/src/tools/gophish_cleaner.py
@@ -50,9 +50,9 @@ def confirm_id(element, assessment_id):
     while True:
         if element != "assessment":
             logging.warning(
-                "NOTE: THIS WILL REMOVE ALL {} DATA ASSOCIATED WITH ASSESSMENT {}".format(
-                    element.upper(), assessment_id
-                )
+                "NOTE: THIS WILL REMOVE ALL %s DATA ASSOCIATED WITH ASSESSMENT %s",
+                element.upper(),
+                assessment_id,
             )
             # Bandit complains about the input() function, but it is safe to
             # use in Python 3, which is required by this project.
@@ -60,9 +60,8 @@ def confirm_id(element, assessment_id):
 
         else:
             logging.warning(
-                "NOTE: THIS WILL REMOVE ALL DATA ASSOCIATED WITH ASSESSMENT {}".format(
-                    assessment_id
-                )
+                "NOTE: THIS WILL REMOVE ALL DATA ASSOCIATED WITH ASSESSMENT %s",
+                assessment_id,
             )
             # Bandit complains about the input() function, but it is safe to
             # use in Python 3, which is required by this project.
@@ -87,7 +86,7 @@ def remove_assessment(api, assessment_id):
         success = False
 
     else:
-        logging.info("Successfully removed all elements of {}".format(assessment_id))
+        logging.info("Successfully removed all elements of %s", assessment_id)
         success = True
 
     return success
@@ -160,9 +159,8 @@ def main() -> None:
         )
     except ValueError:
         logging.critical(
-            '"{}"is not a valid logging level.  Possible values are debug, info, warning, and error.'.format(
-                log_level
-            )
+            '"%s"is not a valid logging level.  Possible values are debug, info, warning, and error.',
+            log_level,
         )
         sys.exit(1)
 
@@ -170,7 +168,7 @@ def main() -> None:
         # Connect to API
         try:
             api = connect_api(args["API_KEY"], args["SERVER"])
-            logging.debug("Connected to: {}".format(args["SERVER"]))
+            logging.debug("Connected to: %s", args["SERVER"])
         except Exception as e:
             logging.critical(e.args[0])
             sys.exit(1)

--- a/src/tools/gophish_complete.py
+++ b/src/tools/gophish_complete.py
@@ -167,14 +167,15 @@ def main() -> None:
         )
     except ValueError:
         logging.critical(
-            f'"{log_level}"is not a valid logging level. Possible values are debug, info, warning, and error.'
+            '"%s"is not a valid logging level. Possible values are debug, info, warning, and error.',
+            log_level,
         )
         sys.exit(1)
 
     # Connect to API
     try:
         api = connect_api(args["API_KEY"], args["SERVER"])
-        logging.debug(f'Connected to: {args["SERVER"]}')
+        logging.debug('Connected to: "%s"', args["SERVER"])
     except Exception as e:
         logging.critical(e.args[0])
         sys.exit(1)

--- a/src/tools/gophish_complete.py
+++ b/src/tools/gophish_complete.py
@@ -167,7 +167,7 @@ def main() -> None:
         )
     except ValueError:
         logging.critical(
-            '"%s"is not a valid logging level. Possible values are debug, info, warning, and error.',
+            '"%s" is not a valid logging level. Possible values are debug, info, warning, and error.',
             log_level,
         )
         sys.exit(1)

--- a/src/tools/gophish_export.py
+++ b/src/tools/gophish_export.py
@@ -386,7 +386,7 @@ def main() -> None:
         )
     except ValueError:
         logging.critical(
-            '"%s"is not a valid logging level. Possible values are debug, info, warning, and error.',
+            '"%s" is not a valid logging level. Possible values are debug, info, warning, and error.',
             log_level,
         )
         sys.exit(1)

--- a/src/tools/gophish_export.py
+++ b/src/tools/gophish_export.py
@@ -99,7 +99,7 @@ def export_targets(api, assessment_id):
             targets.append(target)
 
     logging.info(
-        "%i email targets found for assessment %s.", len(targets), assessment_id
+        "%d email targets found for assessment %s.", len(targets), assessment_id
     )
 
     return targets
@@ -134,7 +134,7 @@ def export_campaigns(api, assessment_id):
     for campaign_id in campaignIDs:
         campaigns.append(get_campaign_data(api, campaign_id))
 
-    logging.info("%i campaigns found for assessment %s.", len(campaigns), assessment_id)
+    logging.info("%d campaigns found for assessment %s.", len(campaigns), assessment_id)
 
     return campaigns
 
@@ -317,8 +317,8 @@ def write_campaign_summary(api, assessment_id):
         file_out.write("\nStart Date: %s" % campaign_data[level]["start_date"])
         file_out.write("\nEnd Date: %s" % campaign_data[level]["end_date"])
         file_out.write("\nRedirect: %s" % campaign_data[level]["redirect"])
-        file_out.write("\nClicks: %i" % campaign_data[level]["clicks"])
-        file_out.write("\nUnique Clicks: %i" % campaign_data[level]["unique_clicks"])
+        file_out.write("\nClicks: %d" % campaign_data[level]["clicks"])
+        file_out.write("\nUnique Clicks: %d" % campaign_data[level]["unique_clicks"])
         file_out.write(
             "\nPercentage Clicks: %f" % campaign_data[level]["percent_clicks"]
         )

--- a/src/tools/gophish_export.py
+++ b/src/tools/gophish_export.py
@@ -366,7 +366,7 @@ def export_user_reports(api, assessment_id):
 
         logging.info(
             "Writing out user report for campaign %s in assessment %s",
-            campaign.name,
+            campaign["id"],
             assessment_id,
         )
 

--- a/src/tools/gophish_export.py
+++ b/src/tools/gophish_export.py
@@ -98,7 +98,9 @@ def export_targets(api, assessment_id):
 
             targets.append(target)
 
-    logging.info(f"{len(targets)} email targets found for assessment {assessment_id}.")
+    logging.info(
+        "%i email targets found for assessment %s.", len(targets), assessment_id
+    )
 
     return targets
 
@@ -132,7 +134,7 @@ def export_campaigns(api, assessment_id):
     for campaign_id in campaignIDs:
         campaigns.append(get_campaign_data(api, campaign_id))
 
-    logging.info(f"{len(campaigns)} campaigns found for assessment {assessment_id}.")
+    logging.info("%i campaigns found for assessment %s.", len(campaigns), assessment_id)
 
     return campaigns
 
@@ -363,7 +365,9 @@ def export_user_reports(api, assessment_id):
         ).stats.clicked
 
         logging.info(
-            f"Writing out user report for campaign {campaign_id} in assessment {assessment_id}"
+            "Writing out user report for campaign %s in assessment %s",
+            campaign.name,
+            assessment_id,
         )
 
         with open(f"{assessment_id}_{campaign_id}_user_report_doc.json", "w") as fp:
@@ -382,7 +386,8 @@ def main() -> None:
         )
     except ValueError:
         logging.critical(
-            f'"{log_level}"is not a valid logging level. Possible values are debug, info, warning, and error.'
+            '"%s"is not a valid logging level. Possible values are debug, info, warning, and error.',
+            log_level,
         )
         sys.exit(1)
 
@@ -390,7 +395,7 @@ def main() -> None:
         # Connect to API
         try:
             api = connect_api(args["API_KEY"], args["SERVER"])
-            logging.debug(f'Connected to: {args["SERVER"]}')
+            logging.debug("Connected to: %s", args["SERVER"])
         except Exception as e:
             logging.critical(e.args[0])
             sys.exit(1)
@@ -407,12 +412,12 @@ def main() -> None:
         with open(f'data_{args["ASSESSMENT_ID"]}.json', "w") as fp:
             json.dump(assessment_dict, fp, indent=4)
 
-        logging.info(f'Data written to data_{args["ASSESSMENT_ID"]}.json')
+        logging.info("Data written to data_%s.json", args["ASSESSMENT_ID"])
 
         export_user_reports(api, args["ASSESSMENT_ID"])
         write_campaign_summary(api, args["ASSESSMENT_ID"])
     else:
         logging.error(
-            f'Assessment "{args["ASSESSMENT_ID"]}" does not exist in GoPhish.'
+            'Assessment "%s" does not exist in GoPhish.', args["ASSESSMENT_ID"]
         )
         sys.exit(1)

--- a/src/tools/gophish_import.py
+++ b/src/tools/gophish_import.py
@@ -52,12 +52,10 @@ def load_landings(api, assessment):
         if page["redirect_url"]:
             new_page.redirect_url = page["redirect_url"]
 
-        # Debug page information, editors may produce a false error or warning for lines 57 - 60
+        # Debug page information
 
         logging.debug("Page Name: %s", new_page.name)
         logging.debug("Redirect ULR: %s", new_page.redirect_url)
-        logging.debug("Capture Credentials: %s", new_page.capture_credentials)
-        logging.debug("Capture Passwords: %s", new_page.capture_passwords)
 
         """
          Catches when a page has already been loaded into GoPhish.

--- a/src/tools/gophish_import.py
+++ b/src/tools/gophish_import.py
@@ -81,7 +81,7 @@ def load_landings(api, assessment):
                     raise
 
         # Returns Landing Page ID
-        logging.info("Landing Page %s loaded.\n", new_page.name)
+        logging.info("Landing Page %s loaded.", new_page.name)
         page["id"] = new_page.id
 
     return pages
@@ -129,12 +129,12 @@ def load_groups(api, assessment):
                             api.groups.delete(old_group.id)
                             logging.info("Re-Loading new group.")
                 else:
-                    logging.error("%s\n", e)
+                    logging.error("%s", e)
                     raise
 
         group["id"] = new_group.id
 
-        logging.info("Group Ready: %s\n", new_group.name)
+        logging.info("Group Ready: %s", new_group.name)
 
     return groups
 
@@ -165,7 +165,7 @@ def build_campaigns(api, assessment):
             except Error as e:
                 if e.message == "Template name already in use":
                     logging.warning(
-                        "%s. Finding previously loaded template to delete.", e
+                        "%s. Finding previously loaded template to delete.", e.message
                     )
                     templates = api.templates.get()
                     logging.debug(
@@ -180,7 +180,7 @@ def build_campaigns(api, assessment):
                             api.templates.delete(old_template.id)
                             logging.info("Re-Loading new template.")
                 else:
-                    logging.error("%s\n", e.message)
+                    logging.error("%s", e.message)
                     raise
 
         # Build SMTP Object
@@ -216,7 +216,7 @@ def build_campaigns(api, assessment):
                             api.smtp.delete(old_smtp.id)
                             logging.info("Re-Loading new SMTP.")
                 else:
-                    logging.error("%s\n", e.message)
+                    logging.error("%s", e.message)
                     raise
 
         # Check to remove any campaigns with the same name
@@ -264,7 +264,7 @@ def main() -> None:
         )
     except ValueError:
         logging.critical(
-            '"%s"is not a valid logging level.  Possible values are debug, info, warning, and error.',
+            '"%s" is not a valid logging level.  Possible values are debug, info, warning, and error.',
             log_level,
         )
         sys.exit(1)
@@ -283,12 +283,12 @@ def main() -> None:
         with open(args["ASSESSMENT_FILE"]) as json_file:
             assessment = json.load(json_file)
     except FileNotFoundError as e:
-        logging.error("%s\n", e)
+        logging.error("%s", e)
         # Stop logging and clean up
         logging.shutdown()
         sys.exit(1)
     except PermissionError as e:
-        logging.error("%s\n", e)
+        logging.error("%s", e)
         # Stop logging and clean up
         logging.shutdown()
         sys.exit(1)

--- a/src/tools/gophish_import.py
+++ b/src/tools/gophish_import.py
@@ -52,7 +52,8 @@ def load_landings(api, assessment):
         if page["redirect_url"]:
             new_page.redirect_url = page["redirect_url"]
 
-        # Debug page information
+        # Debug page information, editors may produce a false error or warning for lines 57 - 60
+
         logging.debug("Page Name: %s", new_page.name)
         logging.debug("Redirect ULR: %s", new_page.redirect_url)
         logging.debug("Capture Credentials: %s", new_page.capture_credentials)

--- a/src/tools/gophish_import.py
+++ b/src/tools/gophish_import.py
@@ -128,7 +128,7 @@ def load_groups(api, assessment):
                             api.groups.delete(old_group.id)
                             logging.info("Re-Loading new group.")
                 else:
-                    logging.error("%s", e)
+                    logging.exception("%s", e)
                     raise
 
         group["id"] = new_group.id
@@ -179,7 +179,7 @@ def build_campaigns(api, assessment):
                             api.templates.delete(old_template.id)
                             logging.info("Re-Loading new template.")
                 else:
-                    logging.error("%s", e.message)
+                    logging.exception("%s", e.message)
                     raise
 
         # Build SMTP Object
@@ -215,7 +215,7 @@ def build_campaigns(api, assessment):
                             api.smtp.delete(old_smtp.id)
                             logging.info("Re-Loading new SMTP.")
                 else:
-                    logging.error("%s", e.message)
+                    logging.exception("%s", e.message)
                     raise
 
         # Check to remove any campaigns with the same name
@@ -245,10 +245,10 @@ def build_campaigns(api, assessment):
                 )
             )
         except Exception as e:
-            logging.error(e)
+            logging.exception(e)
             raise
 
-        logging.info("Campaign %s successfully loaded.\n", campaign["name"])
+        logging.info("Campaign %s successfully loaded.", campaign["name"])
 
 
 def main() -> None:
@@ -282,12 +282,12 @@ def main() -> None:
         with open(args["ASSESSMENT_FILE"]) as json_file:
             assessment = json.load(json_file)
     except FileNotFoundError as e:
-        logging.error("%s", e)
+        logging.exception("%s", e)
         # Stop logging and clean up
         logging.shutdown()
         sys.exit(1)
     except PermissionError as e:
-        logging.error("%s", e)
+        logging.exception("%s", e)
         # Stop logging and clean up
         logging.shutdown()
         sys.exit(1)
@@ -306,8 +306,8 @@ def main() -> None:
         logging.shutdown()
 
     except Exception as e:
-        logging.debug("%s: %s", type(e), e)
-        logging.critical("Closing with an error. Assessment not successfully loaded.\n")
+        logging.exception("%s: %s", type(e), e)
+        logging.critical("Closing with an error. Assessment not successfully loaded.")
         # Stop logging and clean up
         logging.shutdown()
         sys.exit(1)

--- a/src/tools/gophish_import.py
+++ b/src/tools/gophish_import.py
@@ -53,10 +53,10 @@ def load_landings(api, assessment):
             new_page.redirect_url = page["redirect_url"]
 
         # Debug page information
-        logging.debug("Page Name: {}".format(new_page.name))
-        logging.debug("Redirect ULR: {}".format(new_page.redirect_url))
-        logging.debug("Capture Credentials: {}".format(new_page.capture_credentials))
-        logging.debug("Capture Passwords: {}".format(new_page.capture_passwords))
+        logging.debug("Page Name: %s", new_page.name)
+        logging.debug("Redirect ULR: %s", new_page.redirect_url)
+        logging.debug("Capture Credentials: %s", new_page.capture_credentials)
+        logging.debug("Capture Passwords: %s", new_page.capture_passwords)
 
         """
          Catches when a page has already been loaded into GoPhish.
@@ -69,11 +69,11 @@ def load_landings(api, assessment):
                 break
             except Error as e:
                 if e.message == "Page name already in use":
-                    logging.warning(f"{e}. Finding with previously loaded page.")
+                    logging.warning("%s. Finding with previously loaded page.", e)
                     old_pages = api.pages.get()
                     for old_page in old_pages:
                         if old_page.name == new_page.name:
-                            logging.debug(f"Deleting Page with ID {old_page.id}")
+                            logging.debug("Deleting Page with ID %i", old_page.id)
                             api.pages.delete(old_page.id)
                             logging.info("Re-Loading new page.")
                 else:
@@ -81,7 +81,7 @@ def load_landings(api, assessment):
                     raise
 
         # Returns Landing Page ID
-        logging.info(f"Landing Page {new_page.name} loaded.\n")
+        logging.info("Landing Page %s loaded.\n", new_page.name)
         page["id"] = new_page.id
 
     return pages
@@ -92,7 +92,7 @@ def load_groups(api, assessment):
     groups = assessment["groups"]
 
     for group in groups:
-        logging.info(f"Loading Group {group['name']}")
+        logging.info("Loading Group %s", group["name"])
 
         new_group = Group()
         new_group.name = group["name"]
@@ -117,23 +117,24 @@ def load_groups(api, assessment):
                 break
             except Error as e:
                 if e.message == "Group name already in use":
-                    logging.warning(f"{e}. Finding previously loaded group to delete.")
+                    logging.warning("%s. Finding previously loaded group to delete.", e)
                     groups = api.groups.get()
                     logging.debug(
-                        f"Checking {len(groups)} for previously imported group to get ID"
+                        "Checking %i for previously imported group to get ID",
+                        len(groups),
                     )
                     for old_group in groups:
                         if old_group.name == new_group.name:
-                            logging.debug(f"Deleting Group with ID {old_group.id}")
+                            logging.debug("Deleting Group with ID %i", old_group.id)
                             api.groups.delete(old_group.id)
                             logging.info("Re-Loading new group.")
                 else:
-                    logging.error(f"{e}\n")
+                    logging.error("%s\n", e)
                     raise
 
         group["id"] = new_group.id
 
-        logging.info("Group Ready: {}\n".format(new_group.name))
+        logging.info("Group Ready: %s\n", new_group.name)
 
     return groups
 
@@ -142,7 +143,7 @@ def build_campaigns(api, assessment):
     """Build campaigns."""
     logging.info("Building Campaigns.")
     for campaign in assessment["campaigns"]:
-        logging.info(f"Building Campaign: {campaign['name']}")
+        logging.info("Building Campaign: %s", campaign["name"])
 
         # Build Template object
         new_template = Template(
@@ -164,21 +165,22 @@ def build_campaigns(api, assessment):
             except Error as e:
                 if e.message == "Template name already in use":
                     logging.warning(
-                        f"{e}. Finding previously loaded template to delete."
+                        "%s. Finding previously loaded template to delete.", e
                     )
                     templates = api.templates.get()
                     logging.debug(
-                        f"Checking {len(templates)} for previously imported template to get ID"
+                        "Checking %i for previously imported template to get ID",
+                        len(templates),
                     )
                     for old_template in templates:
                         if old_template.name == new_template.name:
                             logging.debug(
-                                f"Deleting Template with ID {old_template.id}"
+                                "Deleting Template with ID %i", old_template.id
                             )
                             api.templates.delete(old_template.id)
                             logging.info("Re-Loading new template.")
                 else:
-                    logging.error(f"{e}\n")
+                    logging.error("%s\n", e.message)
                     raise
 
         # Build SMTP Object
@@ -202,18 +204,19 @@ def build_campaigns(api, assessment):
                 break
             except Error as e:
                 if e.message == "SMTP name already in use":
-                    logging.warning(f"{e}. Finding previously loaded smtp to delete.")
+                    logging.warning("%s. Finding previously loaded smtp to delete.", e)
                     smtps = api.smtp.get()
                     logging.debug(
-                        f"Checking {len(smtps)} for previously imported smtp profiles to get ID"
+                        "Checking %i for previously imported smtp profiles to get ID",
+                        len(smtps),
                     )
                     for old_smtp in smtps:
                         if old_smtp.name == new_smtp.name:
-                            logging.debug(f"Deleting SMTP with ID {old_smtp.id}")
+                            logging.debug("Deleting SMTP with ID %i", old_smtp.id)
                             api.smtp.delete(old_smtp.id)
                             logging.info("Re-Loading new SMTP.")
                 else:
-                    logging.error(f"{e}\n")
+                    logging.error("%s\n", e.message)
                     raise
 
         # Check to remove any campaigns with the same name
@@ -221,10 +224,10 @@ def build_campaigns(api, assessment):
         for old_campaign in old_campaigns:
             if old_campaign.name == campaign["name"]:
                 logging.warning(
-                    f"Previous Campaign found with name {campaign['name']}."
+                    "Previous Campaign found with name %s.", campaign["name"]
                 )
                 logging.warning(
-                    f"Previous Campaign with id {old_campaign.id} being deleted."
+                    "Previous Campaign with id %i being deleted.", old_campaign.id
                 )
                 api.campaigns.delete(old_campaign.id)
 
@@ -246,7 +249,7 @@ def build_campaigns(api, assessment):
             logging.error(e)
             raise
 
-        logging.info(f"Campaign {campaign['name']} successfully loaded.\n")
+        logging.info("Campaign %s successfully loaded.\n", campaign["name"])
 
 
 def main() -> None:
@@ -261,15 +264,14 @@ def main() -> None:
         )
     except ValueError:
         logging.critical(
-            '"{}"is not a valid logging level.  Possible values are debug, info, warning, and error.'.format(
-                log_level
-            )
+            '"%s"is not a valid logging level.  Possible values are debug, info, warning, and error.',
+            log_level,
         )
         sys.exit(1)
 
     try:
         api = connect_api(args["API_KEY"], args["SERVER"])
-        logging.debug("Connected to: {}".format(args["SERVER"]))
+        logging.debug("Connected to: %s", args["SERVER"])
     except Exception as e:
         logging.critical(e.args[0])
         # Stop logging and clean up
@@ -281,12 +283,12 @@ def main() -> None:
         with open(args["ASSESSMENT_FILE"]) as json_file:
             assessment = json.load(json_file)
     except FileNotFoundError as e:
-        logging.error(f"{e}\n")
+        logging.error("%s\n", e)
         # Stop logging and clean up
         logging.shutdown()
         sys.exit(1)
     except PermissionError as e:
-        logging.error(f"{e}\n")
+        logging.error("%s\n", e)
         # Stop logging and clean up
         logging.shutdown()
         sys.exit(1)
@@ -305,7 +307,7 @@ def main() -> None:
         logging.shutdown()
 
     except Exception as e:
-        logging.debug(f"{type(e)}: {e}")
+        logging.debug("%s: %s", type(e), e)
         logging.critical("Closing with an error. Assessment not successfully loaded.\n")
         # Stop logging and clean up
         logging.shutdown()

--- a/src/tools/gophish_import.py
+++ b/src/tools/gophish_import.py
@@ -128,7 +128,9 @@ def load_groups(api, assessment):
                             api.groups.delete(old_group.id)
                             logging.info("Re-Loading new group.")
                 else:
-                    logging.exception("%s", e)
+                    logging.exception(
+                        "Exception encountered when loading group in Gophish (%s)", e
+                    )
                     raise
 
         group["id"] = new_group.id
@@ -179,7 +181,10 @@ def build_campaigns(api, assessment):
                             api.templates.delete(old_template.id)
                             logging.info("Re-Loading new template.")
                 else:
-                    logging.exception("%s", e.message)
+                    logging.exception(
+                        "Exception encountered when loading template in Gophish (%s)",
+                        e.message,
+                    )
                     raise
 
         # Build SMTP Object
@@ -215,7 +220,10 @@ def build_campaigns(api, assessment):
                             api.smtp.delete(old_smtp.id)
                             logging.info("Re-Loading new SMTP.")
                 else:
-                    logging.exception("%s", e.message)
+                    logging.exception(
+                        "Exception encountered when loading SMTP in Gophish (%s)",
+                        e.message,
+                    )
                     raise
 
         # Check to remove any campaigns with the same name
@@ -245,7 +253,9 @@ def build_campaigns(api, assessment):
                 )
             )
         except Exception as e:
-            logging.exception(e)
+            logging.exception(
+                "Exception encountered when loading campaign in Gophish (%s)", e.message
+            )
             raise
 
         logging.info("Campaign %s successfully loaded.", campaign["name"])
@@ -282,12 +292,12 @@ def main() -> None:
         with open(args["ASSESSMENT_FILE"]) as json_file:
             assessment = json.load(json_file)
     except FileNotFoundError as e:
-        logging.exception("%s", e)
+        logging.exception("Unable to locate Assessment file (%s)", e)
         # Stop logging and clean up
         logging.shutdown()
         sys.exit(1)
     except PermissionError as e:
-        logging.exception("%s", e)
+        logging.exception("Permission denied for opening Assessment file (%s)", e)
         # Stop logging and clean up
         logging.shutdown()
         sys.exit(1)
@@ -306,7 +316,9 @@ def main() -> None:
         logging.shutdown()
 
     except Exception as e:
-        logging.exception("%s: %s", type(e), e)
+        logging.exception(
+            "Exception encountered while loading data from Gophish (%s: %s)", type(e), e
+        )
         logging.critical("Closing with an error. Assessment not successfully loaded.")
         # Stop logging and clean up
         logging.shutdown()

--- a/src/tools/gophish_import.py
+++ b/src/tools/gophish_import.py
@@ -55,7 +55,7 @@ def load_landings(api, assessment):
         # Debug page information
 
         logging.debug("Page Name: %s", new_page.name)
-        logging.debug("Redirect ULR: %s", new_page.redirect_url)
+        logging.debug("Redirect URL: %s", new_page.redirect_url)
 
         """
          Catches when a page has already been loaded into GoPhish.
@@ -72,7 +72,7 @@ def load_landings(api, assessment):
                     old_pages = api.pages.get()
                     for old_page in old_pages:
                         if old_page.name == new_page.name:
-                            logging.debug("Deleting Page with ID %i", old_page.id)
+                            logging.debug("Deleting Page with ID %d", old_page.id)
                             api.pages.delete(old_page.id)
                             logging.info("Re-Loading new page.")
                 else:
@@ -119,12 +119,12 @@ def load_groups(api, assessment):
                     logging.warning("%s. Finding previously loaded group to delete.", e)
                     groups = api.groups.get()
                     logging.debug(
-                        "Checking %i for previously imported group to get ID",
+                        "Checking %d for previously imported group to get ID",
                         len(groups),
                     )
                     for old_group in groups:
                         if old_group.name == new_group.name:
-                            logging.debug("Deleting Group with ID %i", old_group.id)
+                            logging.debug("Deleting Group with ID %d", old_group.id)
                             api.groups.delete(old_group.id)
                             logging.info("Re-Loading new group.")
                 else:
@@ -170,13 +170,13 @@ def build_campaigns(api, assessment):
                     )
                     templates = api.templates.get()
                     logging.debug(
-                        "Checking %i for previously imported template to get ID",
+                        "Checking %d for previously imported template to get ID",
                         len(templates),
                     )
                     for old_template in templates:
                         if old_template.name == new_template.name:
                             logging.debug(
-                                "Deleting Template with ID %i", old_template.id
+                                "Deleting Template with ID %d", old_template.id
                             )
                             api.templates.delete(old_template.id)
                             logging.info("Re-Loading new template.")
@@ -211,12 +211,12 @@ def build_campaigns(api, assessment):
                     logging.warning("%s. Finding previously loaded smtp to delete.", e)
                     smtps = api.smtp.get()
                     logging.debug(
-                        "Checking %i for previously imported smtp profiles to get ID",
+                        "Checking %d for previously imported smtp profiles to get ID",
                         len(smtps),
                     )
                     for old_smtp in smtps:
                         if old_smtp.name == new_smtp.name:
-                            logging.debug("Deleting SMTP with ID %i", old_smtp.id)
+                            logging.debug("Deleting SMTP with ID %d", old_smtp.id)
                             api.smtp.delete(old_smtp.id)
                             logging.info("Re-Loading new SMTP.")
                 else:
@@ -234,7 +234,7 @@ def build_campaigns(api, assessment):
                     "Previous Campaign found with name %s.", campaign["name"]
                 )
                 logging.warning(
-                    "Previous Campaign with id %i being deleted.", old_campaign.id
+                    "Previous Campaign with id %d being deleted.", old_campaign.id
                 )
                 api.campaigns.delete(old_campaign.id)
 

--- a/src/tools/gophish_test.py
+++ b/src/tools/gophish_test.py
@@ -140,7 +140,7 @@ def main() -> None:
         )
     except ValueError:
         logging.critical(
-            '"%s"is not a valid logging level.  Possible values are debug, info, warning, and error.',
+            '"%s" is not a valid logging level.  Possible values are debug, info, warning, and error.',
             log_level,
         )
         sys.exit(1)

--- a/src/tools/gophish_test.py
+++ b/src/tools/gophish_test.py
@@ -54,7 +54,7 @@ def get_campaigns(api, assessment_id):
             assessmentCampaigns.append(campaign)
 
     # Sets err to true if assessmentCampaigns has 0 length.
-    logging.debug("Num Campaigns: %i", len(assessmentCampaigns))
+    logging.debug("Num Campaigns: %d", len(assessmentCampaigns))
     if not len(assessmentCampaigns):
         logging.warning("No Campaigns found for %s", assessment_id)
 

--- a/src/tools/gophish_test.py
+++ b/src/tools/gophish_test.py
@@ -54,9 +54,9 @@ def get_campaigns(api, assessment_id):
             assessmentCampaigns.append(campaign)
 
     # Sets err to true if assessmentCampaigns has 0 length.
-    logging.debug(f"Num Campaigns: {len(assessmentCampaigns)}")
+    logging.debug("Num Campaigns: %i", len(assessmentCampaigns))
     if not len(assessmentCampaigns):
-        logging.warning("No Campaigns found for {}".format(assessment_id))
+        logging.warning("No Campaigns found for %s", assessment_id)
 
     return assessmentCampaigns
 
@@ -121,7 +121,7 @@ def campaign_test(api, assessmentCampaigns, assessment_id):
         )
 
         postCampaign = api.campaigns.post(postCampaign)
-        logging.debug("Test Campaign added: {}".format(postCampaign.name))
+        logging.debug("Test Campaign added: %s", postCampaign.name)
 
     logging.info("All Test campaigns added.")
 
@@ -140,16 +140,15 @@ def main() -> None:
         )
     except ValueError:
         logging.critical(
-            '"{}"is not a valid logging level.  Possible values are debug, info, warning, and error.'.format(
-                log_level
-            )
+            '"%s"is not a valid logging level.  Possible values are debug, info, warning, and error.',
+            log_level,
         )
         sys.exit(1)
 
     # Connect to API
     try:
         api = connect_api(args["API_KEY"], args["SERVER"])
-        logging.debug("Connected to: {}".format(args["SERVER"]))
+        logging.debug("Connected to: %s", args["SERVER"])
     except Exception as e:
         logging.critical(e.args[0])
         sys.exit(1)

--- a/src/util/input.py
+++ b/src/util/input.py
@@ -75,7 +75,7 @@ def get_time_input(type_, time_zone, default=""):
             input_time = datetime.strptime(input_time, "%m/%d/%Y %H:%M")
             break
         except ValueError:
-            logging.error("Invalid time input: {}".format(input_time))
+            logging.error("Invalid time input: %s", input_time)
 
     # Convert time to ISO format to be returned.
     return pytz.timezone(time_zone).localize(input_time).isoformat()


### PR DESCRIPTION
## 🗣 Description ##

The changes on this branch involve changing all the f-strings and .format style strings in logging messages to the C style string format. 

A small tweak was also made on `gophish-export.py` line 368-369 to change from `campaign_id` to `campaign["id"]`, which will improve readability of the message. `campaign_id` is a Gophish generated integer, which does not really work well with the rest of the statement. `campaign["id"]` is the actual campaign name sourced from Gophish. 

## 💭 Motivation and context ##

This change is necessary to bring gophish-tools in line with the rest of the best practices, which include using the C-style format strings for Python logging. The repository source code was using a mixture of f-strings, .format, and C-style formatting in logging messages. Now the repository will have more consistency in this regard. 

## 🧪 Testing ##

I ran Pytest just to make sure everything still works as intended, and received all green lights. I tested the changes by importing them into the COOL environment and running the LiPCA Setup script to make sure that logging was still working as intended. 

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
