### PR TITLE
Update assessment builder confirmation prompts

### DIFF
--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -56,7 +56,7 @@ CONFIRMATION_PROMPT = "\nDo you need to modify any of the values for this campai
 def set_time_zone():
     """Select a timezone from a list of US-based time zones.
 
-    : return Time zone name based on pytz.
+    Returns: Time zone name based on pytz.
     """
     # TODO Allow for a select more option to get access to full list of Time Zones
 

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -50,11 +50,13 @@ AUTO_FORWARD = """
                 </html>
                """
 
+CONFIRMATION_PROMPT = "\nDo you need to modify any of the values for this campaign?"
+
 
 def set_time_zone():
     """Select a timezone from a list of US-based time zones.
 
-    :return: Time zone name based on pytz.
+    : return Time zone name based on pytz.
     """
     # TODO Allow for a select more option to get access to full list of Time Zones
 
@@ -103,7 +105,7 @@ def display_list_pages(assessment):
 def build_assessment(assessment_id):
     """Walk user through building a new assessment document.
 
-    :return an assessment object
+    : return an assessment object
     """
     logging.info("Building Assessment")
     # Initializes assessment object with ID and timezone
@@ -212,7 +214,7 @@ def review_campaign(campaign):
                         )
                     )
 
-        if yes_no_prompt("\nChanges Required") == "yes":
+        if yes_no_prompt(CONFIRMATION_PROMPT) == "yes":
             completer = WordCompleter(
                 campaign_dict.keys().remove("template"), ignore_case=True
             )
@@ -472,7 +474,10 @@ def build_emails(domains, labels):
                             targets.append(target)
                 else:
                     logging.error("{} Formatting Errors".format(len(format_error)))
-                    if yes_no_prompt("Would you like to correct each here") == "yes":
+                    if (
+                        yes_no_prompt("Would you like to correct each here? (yes/no)")
+                        == "yes"
+                    ):
                         for email in format_error:
                             email[2] = prompt(
                                 "Correct Email Formatting: ",
@@ -504,7 +509,10 @@ def build_emails(domains, labels):
                     logging.error(
                         "{} Domain Miss Match Errors".format(len(format_error))
                     )
-                    if yes_no_prompt("Would you like to correct each here") == "yes":
+                    if (
+                        yes_no_prompt("Would you like to correct each here? (yes/no)")
+                        == "yes"
+                    ):
                         for email in domain_miss_match:
                             while True:
                                 email[2] = prompt(
@@ -568,7 +576,7 @@ def build_pages(id_):
     for page_num in range(int(num_pages)):
         logging.info(f"Building Page {page_num + 1}")
         temp_page = Page()
-        auto_forward = yes_no_prompt("    Will this page auto forward")
+        auto_forward = yes_no_prompt("    Will this page auto forward?")
 
         if auto_forward == "yes":
 
@@ -581,7 +589,7 @@ def build_pages(id_):
         else:
             temp_page.name = f"{id_}-{page_num+1}-Landing"
 
-            forward = yes_no_prompt("    Will this page forward after action")
+            forward = yes_no_prompt("    Will this page forward after action? (yes/no)")
             if forward == "yes":
                 temp_page.capture_credentials = True
                 temp_page.redirect_url = get_input("    URL to Redirect to:")
@@ -629,7 +637,7 @@ def review_page(page):
             if key != "html":
                 print("{}: {}".format(key, value))
                 page_keys.append(key)
-        if yes_no_prompt("Changes Required") == "yes":
+        if yes_no_prompt(CONFIRMATION_PROMPT) == "yes":
             completer = WordCompleter(page_keys, ignore_case=True)
 
             # Loops to get valid Field name form user.

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -105,7 +105,7 @@ def display_list_pages(assessment):
 def build_assessment(assessment_id):
     """Walk user through building a new assessment document.
 
-    : return an assessment object
+    Returns: an assessment object
     """
     logging.info("Building Assessment")
     # Initializes assessment object with ID and timezone
@@ -506,9 +506,7 @@ def build_emails(domains, labels):
                             validator=EmailValidator(),
                         )
                 else:
-                    logging.error(
-                        "{} Domain Mismatch Errors".format(len(format_error))
-                    )
+                    logging.error("{} Domain Mismatch Errors".format(len(format_error)))
                     if (
                         yes_no_prompt("Would you like to correct each here? (yes/no)")
                         == "yes"

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -59,6 +59,7 @@ def set_time_zone():
     Returns: Time zone name based on pytz.
     """
     # TODO Allow for a select more option to get access to full list of Time Zones
+    # See issue: https://github.com/cisagov/gophish-tools/issues/49
 
     # Creates list of US Time Zones
     time_zone = list()

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -507,7 +507,7 @@ def build_emails(domains, labels):
                         )
                 else:
                     logging.error(
-                        "{} Domain Miss Match Errors".format(len(format_error))
+                        "{} Domain Mismatch Errors".format(len(format_error))
                     )
                     if (
                         yes_no_prompt("Would you like to correct each here? (yes/no)")


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Updated the wording for confirmation prompts in the current gophish-tools assessment builder logic. While making this change, it was also a good time to convert the prompt string value (previously hard coded in multiple places) to a "constant" that's a single touch point in the future. I also updated and added punctuation and minor formatting fixes I noticed to clean things up a bit.


## 💭 Motivation and context ##

The feedback from our recent demos and testing proved that the previous prompt confirmation was a bit confusing in how it was presented to the user. As a group, we decided to change the wording to reduce confusion in the future. The other small cleanup items just made sense to address while working there and able to do complete quickly. 


## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

Made changes to prompt values and rebuilt and ran the setup process to confirm the values and wording was correct. Screen capture of the resulting test is included below.


## 📷 Screenshots (if appropriate) ##

https://user-images.githubusercontent.com/6486652/135345441-f3942251-31ad-4e94-9b1e-ba993b2703ab.mov

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
