### PR TITLE
Use Regular Expressions to validate Assessment Identifiers 

### DIFF
--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.8"
+__version__ = "0.0.8-rc.1"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9"
+__version__ = "0.0.9-rc.1"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9-rc.4"
+__version__ = "0.0.9-rc.5"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9-rc.6"
+__version__ = "0.0.9"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9"
+__version__ = "0.0.9-rc.7"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9-rc.2"
+__version__ = "0.0.9-rc.3"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9"
+__version__ = "0.0.8"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9-rc.1"
+__version__ = "0.0.9-rc.2"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9-rc.3"
+__version__ = "0.0.9-rc.4"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9-rc.7"
+__version__ = "0.0.9"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9-rc.5"
+__version__ = "0.0.9-rc.6"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.8-rc.1"
+__version__ = "0.0.9"

--- a/src/tools/gophish_export.py
+++ b/src/tools/gophish_export.py
@@ -403,11 +403,14 @@ def main() -> None:
     pattern = re.compile("^RV([0-9]){4}")
     match = pattern.match(args["ASSESSMENT_ID"])
 
+    print(args["ASSESSMENT_ID"])
+    print(match)
+
     if match is None:
         logging.critical('"%s" is an invalid assessment_id format. Example: RV1234')
         sys.exit(1)
 
-    if assessment_exists(api, args["ASSESSMENT_ID"]):
+    if match and assessment_exists(api, args["ASSESSMENT_ID"]):
         assessment_dict: Dict = dict()
 
         # Add targets list to assessment dict.

--- a/src/tools/gophish_export.py
+++ b/src/tools/gophish_export.py
@@ -403,8 +403,8 @@ def main() -> None:
 
     if not validate_assessment_id(args["ASSESSMENT_ID"]):
         logging.critical(
-            '"%s" is an invalid assessment_id format. Assessment Identifiers begin with RV and followed by a 4 or 5 '
-            "digit numerical sequence. Example: RV1234",
+            '"%s" is an invalid assessment_id format. Assessment identifiers begin with RV and are followed by '
+            " a 4 or 5 digit numerical sequence. Examples: RV1234, RV12345",
             args["ASSESSMENT_ID"],
         )
         sys.exit(1)

--- a/src/tools/gophish_export.py
+++ b/src/tools/gophish_export.py
@@ -32,6 +32,7 @@ import requests
 
 # cisagov Libraries
 from tools.connect import connect_api
+from util.validate import validate_assessment_id
 
 from ._version import __version__
 
@@ -39,21 +40,6 @@ from ._version import __version__
 # as default for https connections, which can not be  verified by a third
 # party; thus, an SSL insecure request warning is produced.
 requests.packages.urllib3.disable_warnings()
-
-
-def assessment_id_valid(assessment_id):
-    """Check if the provided assessment_id is matching the valid assessment_id format. Example: RV1234.
-
-    Args:
-        assessment_id (string): Assessment identifier to validate.
-
-    Returns:
-        match: the result of a regular expression match.
-    """
-    pattern = re.compile("^RV([0-9]){4}")
-    match = pattern.match(assessment_id)
-
-    return match
 
 
 def assessment_exists(api, assessment_id):
@@ -415,7 +401,7 @@ def main() -> None:
             logging.critical(e.args[0])
             sys.exit(1)
 
-    if not assessment_id_valid(args["ASSESSMENT_ID"]):
+    if not validate_assessment_id(args["ASSESSMENT_ID"]):
         logging.critical(
             '"%s" is an invalid assessment_id format. Example: RV1234',
             args["ASSESSMENT_ID"],

--- a/src/tools/gophish_export.py
+++ b/src/tools/gophish_export.py
@@ -403,7 +403,8 @@ def main() -> None:
 
     if not validate_assessment_id(args["ASSESSMENT_ID"]):
         logging.critical(
-            '"%s" is an invalid assessment_id format. Example: RV1234',
+            '"%s" is an invalid assessment_id format. Assessment Identifiers begin with RV and followed by a 4 or 5 '
+            "digit numerical sequence. Example: RV1234",
             args["ASSESSMENT_ID"],
         )
         sys.exit(1)

--- a/src/tools/gophish_export.py
+++ b/src/tools/gophish_export.py
@@ -403,7 +403,7 @@ def main() -> None:
     pattern = re.compile("^RV([0-9]){4}")
     match = pattern.match(args["ASSESSMENT_ID"])
 
-    if match is False:
+    if match is None:
         logging.critical('"%s" is an invalid assessment_id format. Example: RV1234')
         sys.exit(1)
 

--- a/src/tools/gophish_export.py
+++ b/src/tools/gophish_export.py
@@ -41,6 +41,21 @@ from ._version import __version__
 requests.packages.urllib3.disable_warnings()
 
 
+def assessment_id_valid(assessment_id):
+    """Check if the provided assessment_id is matching the valid assessment_id format. Example: RV1234.
+
+    Args:
+        assessment_id (string): Assessment identifier to validate.
+
+    Returns:
+        match: the result of a regular expression match.
+    """
+    pattern = re.compile("^RV([0-9]){4}")
+    match = pattern.match(assessment_id)
+
+    return match
+
+
 def assessment_exists(api, assessment_id):
     """Check if GoPhish has at least one campaign for designated assessment.
 
@@ -400,17 +415,14 @@ def main() -> None:
             logging.critical(e.args[0])
             sys.exit(1)
 
-    pattern = re.compile("^RV([0-9]){4}")
-    match = pattern.match(args["ASSESSMENT_ID"])
-
-    print(args["ASSESSMENT_ID"])
-    print(match)
-
-    if match is None:
-        logging.critical('"%s" is an invalid assessment_id format. Example: RV1234')
+    if not assessment_id_valid(args["ASSESSMENT_ID"]):
+        logging.critical(
+            '"%s" is an invalid assessment_id format. Example: RV1234',
+            args["ASSESSMENT_ID"],
+        )
         sys.exit(1)
 
-    if match and assessment_exists(api, args["ASSESSMENT_ID"]):
+    if assessment_exists(api, args["ASSESSMENT_ID"]):
         assessment_dict: Dict = dict()
 
         # Add targets list to assessment dict.

--- a/src/tools/gophish_export.py
+++ b/src/tools/gophish_export.py
@@ -400,6 +400,13 @@ def main() -> None:
             logging.critical(e.args[0])
             sys.exit(1)
 
+    pattern = re.compile("^RV([0-9]){4}")
+    match = pattern.match(args["ASSESSMENT_ID"])
+
+    if match is False:
+        logging.critical('"%s" is an invalid assessment_id format. Example: RV1234')
+        sys.exit(1)
+
     if assessment_exists(api, args["ASSESSMENT_ID"]):
         assessment_dict: Dict = dict()
 

--- a/src/util/validate.py
+++ b/src/util/validate.py
@@ -24,8 +24,7 @@ def validate_assessment_id(assessment_id):
     Returns:
         match: the result of a regular expression match.
     """
-    pattern = re.compile("^RV([0-9]){4}")
-    match = pattern.match(assessment_id)
+    match = re.match(r"^RV\d{4}", assessment_id)
 
     return match
 

--- a/src/util/validate.py
+++ b/src/util/validate.py
@@ -15,6 +15,21 @@ EMAIL_TEMPLATE = {
 }
 
 
+def validate_assessment_id(assessment_id):
+    """Validate that the provided assessment_id is matching the valid assessment_id format. Example: RV1234.
+
+    Args:
+        assessment_id (string): Assessment identifier to validate.
+
+    Returns:
+        match: the result of a regular expression match.
+    """
+    pattern = re.compile("^RV([0-9]){4}")
+    match = pattern.match(assessment_id)
+
+    return match
+
+
 def validate_email(email):
     """Validate email format.
 

--- a/src/util/validate.py
+++ b/src/util/validate.py
@@ -22,11 +22,9 @@ def validate_assessment_id(assessment_id):
         assessment_id (string): Assessment identifier to validate.
 
     Returns:
-        match: the result of a regular expression match.
+        match: The result of a regular expression match.
     """
-    match = re.match(r"^RV\d{4}", assessment_id)
-
-    return match
+    return re.match(r"^RV\d{4,5}$", assessment_id)
 
 
 def validate_email(email):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5,7 +5,12 @@
 import pytest
 
 # cisagov Libraries
-from util.validate import FormatError, validate_domain, validate_email
+from util.validate import (
+    FormatError,
+    validate_assessment_id,
+    validate_domain,
+    validate_email,
+)
 
 
 @pytest.mark.parametrize(
@@ -35,3 +40,15 @@ def test_validate_domain_valid(email, domain):
 def test_validate_domain_invalid(email, domain):
     """Test an invalid domain."""
     assert not validate_domain(email, domain)
+
+
+@pytest.mark.parametrize("assessment_id", ["RV1234"])
+def test_validate_assessment_id_valid(assessment_id):
+    """Test a valid assessment_id."""
+    assert validate_assessment_id(assessment_id)
+
+
+@pytest.mark.parametrize("assessment_id", ["RV...."])
+def test_validate_assessment_id_invalid(assessment_id):
+    """Test an invalid assessment_id."""
+    assert not validate_assessment_id(assessment_id)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Gophish-export is modified to validate assessment_id input prior to processing. This corrects some errors in processing that can come from invalid or malformed input. 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

This change is in relation to https://github.com/cisagov/gophish-tools/issues/11 .  A partial assessment_id like "RV" could be passed to gophish-export, resulting in it matching all campaigns beginning in RV (which is all campaigns for all assessments). A regex validator was added to validate that the assessment_id matches the known format of assessments. 

Closes #11 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Gophish-export was run with ``assessment_id = "RV"`` and confirmed that an error message was shown to the user, and the process would exit. 

Pytest cases were added to validate that the Regex matched a valid assessment ID format, and that it would not match an invalid value. 

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
