### PR TITLE
Ensure credentials are not being stored or captured

### DIFF
--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9"
+__version__ = "0.0.9-rc.1"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.9-rc.1"
+__version__ = "0.0.10"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.10-rc.1"
+__version__ = "0.0.10-rc.2"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.10-rc.2"
+__version__ = "0.0.10"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.10"
+__version__ = "0.1.0"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.8"
+__version__ = "0.0.9"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.0.10"
+__version__ = "0.0.10-rc.1"

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -576,12 +576,12 @@ def build_pages(id_):
         logging.info(f"Building Page {page_num + 1}")
         temp_page = Page()
         auto_forward = yes_no_prompt("    Will this page auto forward?")
+        temp_page.capture_credentials = False
+        temp_page.capture_passwords = False
 
         if auto_forward == "yes":
 
             setattr(temp_page, "name", f"{id_}-{page_num+1}-AutoForward")
-            temp_page.capture_credentials = False
-            temp_page.capture_passwords = False
             temp_page.html = AUTO_FORWARD
             temp_page.redirect_url = get_input("    URL to Redirect to:")
 
@@ -590,12 +590,7 @@ def build_pages(id_):
 
             forward = yes_no_prompt("    Will this page forward after action? (yes/no)")
             if forward == "yes":
-                temp_page.capture_credentials = False
                 temp_page.redirect_url = get_input("    URL to Redirect to:")
-            else:
-                temp_page.capture_credentials = False
-
-            temp_page.capture_passwords = False
 
             # Receives the file name and checks if it exists.
             while True:

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -580,14 +580,12 @@ def build_pages(id_):
         temp_page.capture_passwords = False
 
         if auto_forward == "yes":
-
             setattr(temp_page, "name", f"{id_}-{page_num+1}-AutoForward")
             temp_page.html = AUTO_FORWARD
             temp_page.redirect_url = get_input("    URL to Redirect to:")
 
         else:
             temp_page.name = f"{id_}-{page_num+1}-Landing"
-
             forward = yes_no_prompt("    Will this page forward after action? (yes/no)")
             if forward == "yes":
                 temp_page.redirect_url = get_input("    URL to Redirect to:")

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -580,7 +580,7 @@ def build_pages(id_):
         if auto_forward == "yes":
 
             setattr(temp_page, "name", f"{id_}-{page_num+1}-AutoForward")
-            temp_page.capture_credentials = True
+            temp_page.capture_credentials = False
             temp_page.capture_passwords = False
             temp_page.html = AUTO_FORWARD
             temp_page.redirect_url = get_input("    URL to Redirect to:")
@@ -590,7 +590,7 @@ def build_pages(id_):
 
             forward = yes_no_prompt("    Will this page forward after action? (yes/no)")
             if forward == "yes":
-                temp_page.capture_credentials = True
+                temp_page.capture_credentials = False
                 temp_page.redirect_url = get_input("    URL to Redirect to:")
             else:
                 temp_page.capture_credentials = False


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Minor revision to configure all campaigns to not allow either credentials or passwords to be captured by Gophish.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Discussing with Kelly Theile and the PCA team, we discussed if passwords are being stored in plaintext (#52) and we were informed that we are not allowed to receive any credentials in any form (plaintext or encrypted) for legal reasons. Credentials must be dropped by the landing pages. This change ensures that no credential or password data is captured. 

In addition, setting the capture credential and password  boolean values was done in one place, before being repeated on each branch of execution. 

Closes #52 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

This was tested by bringing the code changes into our LiPCA process and checking that the campaigns created afterwards were no longer configured to capture submitted data. After setting capture credentials to false, the checkbox in the Gophish GUI for capture submitted data is no longer set. 


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
