### PR TITLE
Add check to ensure supplied campaign launch/complete times are valid

### DIFF
--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.1-rc.6"
+__version__ = "0.1.1-rc.7"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.1"
+__version__ = "0.1.1-rc.1"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.1-rc.1"
+__version__ = "0.1.1-rc.2"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.1-rc.7"
+__version__ = "0.1.1"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.1-rc.2"
+__version__ = "0.1.1-rc.3"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.1-rc.5"
+__version__ = "0.1.1-rc.6"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.1"
+__version__ = "0.1.1-rc.8"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.1-rc.8"
+__version__ = "0.1.1-rc.9"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.1-rc.4"
+__version__ = "0.1.1-rc.5"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.1-rc.3"
+__version__ = "0.1.1-rc.4"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this project."""
-__version__ = "0.1.1-rc.9"
+__version__ = "0.1.1"

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -158,7 +158,7 @@ def build_campaigns(assessment, campaign_number, template_smtp):
     # Get Launch Time
     while True:
         campaign.launch_date = get_time_input("start", assessment.timezone)
-
+        logging.info("Campaign launch date: %s", campaign.launch_date)
         if (
             campaign.launch_date
             > pytz.timezone(assessment.timezone).localize(datetime.now()).isoformat()
@@ -169,7 +169,7 @@ def build_campaigns(assessment, campaign_number, template_smtp):
 
     while True:
         campaign.complete_date = get_time_input("end", assessment.timezone)
-
+        logging.info("Campaign complete date: %s", campaign.complete_date)
         if campaign.complete_date > campaign.launch_date:
             break
         else:

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -16,7 +16,7 @@ Options:
 # Standard Python Libraries
 import copy
 import csv
-import datetime
+from datetime import datetime
 import json
 import logging
 import sys

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -168,15 +168,15 @@ def build_campaigns(assessment, campaign_number, template_smtp):
     while True:
         campaign.complete_date = get_time_input("end", assessment.timezone)
 
-        if campaign.complete_date < campaign.launch_date:
-            logging.error("Complete Date is not after launch Date.")
-
-        elif campaign.complete_date < datetime.now(campaign_tz).isoformat():
-            logging.error("Complete date is not after the current datetime.")
-
+        if campaign.complete_date > campaign.launch_date:
+            pass  # Do nothing yet and continue checks
         else:
-            # else we have valid complete dates
-            break
+            logging.error("Complete Date is not after Launch Date.")
+
+        if campaign.complete_date > datetime.now(campaign_tz).isoformat():
+            break  # Valid input, break out of loop
+        else:
+            logging.error("Complete date is not after the current datetime.")
 
     campaign.smtp, campaign.template = import_email(
         assessment, campaign_number, template_smtp

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -155,11 +155,11 @@ def build_campaigns(assessment, campaign_number, template_smtp):
     logging.info("Building Campaign %s", assessment.id)
     campaign = Campaign(name=assessment.id)
     campaign_tz = pytz.timezone(assessment.timezone)
-
+    logging.info("Assessment timezone: %s", assessment.timezone)
     # Get Launch Time
     while True:
         campaign.launch_date = get_time_input("start", assessment.timezone)
-
+        logging.info("Campaign launch date: %s", campaign.launch_date)
         if campaign.launch_date > datetime.now(campaign_tz).isoformat():
             break
         else:
@@ -167,7 +167,9 @@ def build_campaigns(assessment, campaign_number, template_smtp):
 
     while True:
         campaign.complete_date = get_time_input("end", assessment.timezone)
-
+        datetime_now = datetime.now(campaign_tz).isoformat()
+        logging.info("Campaign complete date: %s", campaign.complete_date)
+        logging.info("Datetime_now: %s", datetime_now)
         if campaign.complete_date > campaign.launch_date:
             break
         else:

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -171,7 +171,7 @@ def build_campaigns(assessment, campaign_number, template_smtp):
         if campaign.complete_date > campaign.launch_date:
             pass  # Do nothing yet and continue checks
         else:
-            logging.error("Complete Date is not after Launch Date.")
+            logging.error("Complete date is not after launch date.")
 
         if campaign.complete_date > datetime.now(campaign_tz).isoformat():
             break  # Valid input, break out of loop

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -168,15 +168,15 @@ def build_campaigns(assessment, campaign_number, template_smtp):
     while True:
         campaign.complete_date = get_time_input("end", assessment.timezone)
 
-        if campaign.complete_date > campaign.launch_date:
-            break
-        else:
-            logging.error("Complete Date is not after Launch Date.")
+        if campaign.complete_date < campaign.launch_date:
+            logging.error("Complete Date is not after launch Date.")
 
-        if campaign.complete_date > datetime.now(campaign_tz).isoformat():
-            break
-        else:
+        elif campaign.complete_date < datetime.now(campaign_tz).isoformat():
             logging.error("Complete date is not after the current datetime.")
+
+        else:
+            # else we have valid complete dates
+            break
 
     campaign.smtp, campaign.template = import_email(
         assessment, campaign_number, template_smtp

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -155,11 +155,11 @@ def build_campaigns(assessment, campaign_number, template_smtp):
     logging.info("Building Campaign %s", assessment.id)
     campaign = Campaign(name=assessment.id)
     campaign_tz = pytz.timezone(assessment.timezone)
-    logging.info("Assessment timezone: %s", assessment.timezone)
+
     # Get Launch Time
     while True:
         campaign.launch_date = get_time_input("start", assessment.timezone)
-        logging.info("Campaign launch date: %s", campaign.launch_date)
+
         if campaign.launch_date > datetime.now(campaign_tz).isoformat():
             break
         else:
@@ -167,9 +167,7 @@ def build_campaigns(assessment, campaign_number, template_smtp):
 
     while True:
         campaign.complete_date = get_time_input("end", assessment.timezone)
-        datetime_now = datetime.now(campaign_tz).isoformat()
-        logging.info("Campaign complete date: %s", campaign.complete_date)
-        logging.info("Datetime_now: %s", datetime_now)
+
         if campaign.complete_date > campaign.launch_date:
             break
         else:

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -154,31 +154,26 @@ def build_campaigns(assessment, campaign_number, template_smtp):
     # Set up component holders
     logging.info("Building Campaign %s", assessment.id)
     campaign = Campaign(name=assessment.id)
+    campaign_tz = pytz.timezone(assessment.timezone)
 
     # Get Launch Time
     while True:
         campaign.launch_date = get_time_input("start", assessment.timezone)
-        logging.info("Campaign launch date: %s", campaign.launch_date)
-        if (
-            campaign.launch_date
-            > pytz.timezone(assessment.timezone).localize(datetime.now()).isoformat()
-        ):
+
+        if campaign.launch_date > datetime.now(campaign_tz).isoformat():
             break
         else:
             logging.error("Launch date is not after the current datetime")
 
     while True:
         campaign.complete_date = get_time_input("end", assessment.timezone)
-        logging.info("Campaign complete date: %s", campaign.complete_date)
+
         if campaign.complete_date > campaign.launch_date:
             break
         else:
             logging.error("Complete Date is not after Launch Date.")
 
-        if (
-            campaign.complete_date
-            > pytz.timezone(assessment.timezone).localize(datetime.now()).isoformat()
-        ):
+        if campaign.complete_date > datetime.now(campaign_tz).isoformat():
             break
         else:
             logging.error("Complete date is not after the current datetime.")

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -16,6 +16,7 @@ Options:
 # Standard Python Libraries
 import copy
 import csv
+import datetime
 import json
 import logging
 import sys
@@ -155,7 +156,13 @@ def build_campaigns(assessment, campaign_number, template_smtp):
     campaign = Campaign(name=assessment.id)
 
     # Get Launch Time
-    campaign.launch_date = get_time_input("start", assessment.timezone)
+    while True:
+        campaign.launch_date = get_time_input("start", assessment.timezone)
+
+        if campaign.launch_date > datetime.now():
+            break
+        else:
+            logging.error("Launch date is not after the current datetime")
 
     while True:
         campaign.complete_date = get_time_input("end", assessment.timezone)
@@ -164,6 +171,11 @@ def build_campaigns(assessment, campaign_number, template_smtp):
             break
         else:
             logging.error("Complete Date is not after Launch Date.")
+
+        if campaign.complete_date > datetime.now():
+            break
+        else:
+            logging.error("Complete date is not after the current datetime.")
 
     campaign.smtp, campaign.template = import_email(
         assessment, campaign_number, template_smtp

--- a/src/assessment/builder.py
+++ b/src/assessment/builder.py
@@ -159,7 +159,10 @@ def build_campaigns(assessment, campaign_number, template_smtp):
     while True:
         campaign.launch_date = get_time_input("start", assessment.timezone)
 
-        if campaign.launch_date > datetime.now():
+        if (
+            campaign.launch_date
+            > pytz.timezone(assessment.timezone).localize(datetime.now()).isoformat()
+        ):
             break
         else:
             logging.error("Launch date is not after the current datetime")
@@ -172,7 +175,10 @@ def build_campaigns(assessment, campaign_number, template_smtp):
         else:
             logging.error("Complete Date is not after Launch Date.")
 
-        if campaign.complete_date > datetime.now():
+        if (
+            campaign.complete_date
+            > pytz.timezone(assessment.timezone).localize(datetime.now()).isoformat()
+        ):
             break
         else:
             logging.error("Complete date is not after the current datetime.")


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Some validation has been provided to ensure that the supplied launch/complete times for a campaign are sane, in that they do not occur before the current time. 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

During development of some previous tickets, it was found that a user could supply aforementioned values before the current time. Gophish-tools would then schedule the campaigns as indicated, and Gophish would automatically close them if the complete date was prior to the current time. This is not desirable behavior from our operators. 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Testing of the new changes was done by attempting to schedule a campaign with a date prior to the current time, such as 1/1/1901 12:00. An error message is displayed until valid input is provided. 

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
