### PR TITLE
Make script executable again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ WORKDIR $GOPHISH_TOOLS_SRC
 COPY . $GOPHISH_TOOLS_SRC
 
 RUN pip install --no-cache-dir .
-RUN chmod +x ${GOPHISH_TOOLS_SRC}/var/getenv
 RUN ln -snf ${GOPHISH_TOOLS_SRC}/var/getenv /usr/local/bin
 
 USER cisa

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this project."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/var/getenv
+++ b/var/getenv
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 echo '################################################################################'
 echo '# The following output is used to setup aliases to containerized commands.'
 echo '# To apply these changes in a shell, eval the output of this container:'

--- a/var/getenv
+++ b/var/getenv
@@ -16,12 +16,15 @@ cd /usr/local/bin || exit
 # Create output that can be eval'd to create aliases for the various
 # commands in gophish-tools
 for f in pca-*; do
+  # shellcheck disable=SC1083,SC2086
   echo alias $f=\"docker run -it --network host --rm --volume \\\`pwd\\\`:/home/cisa \\\"\\\${GOPHISH_TOOLS_IMAGE:-cisagov/gophish-tools}\\\" $f\"
 done
 
 for f in gophish-*; do
+  # shellcheck disable=SC1083,SC2086
   echo alias $f=\"docker run -it --network host --rm --volume \\\`pwd\\\`:/home/cisa \\\"\\\${GOPHISH_TOOLS_IMAGE:-cisagov/gophish-tools}\\\" $f\"
 done
 
 # Create an alias to execute a shell in the gophish-tools container
+# shellcheck disable=SC1083,SC2086
 echo alias gophish-tools-bash=\"docker run -it --rm --network host --volume \\\`pwd\\\`:/home/cisa \\\"\\\${GOPHISH_TOOLS_IMAGE:-cisagov/gophish-tools}\\\" /bin/bash\"

--- a/var/getenv
+++ b/var/getenv
@@ -1,27 +1,25 @@
 #!/bin/bash
 
-echo '################################################################################'
-echo '# The following output is used to setup aliases to containerized commands.'
-echo '# To apply these changes in a shell, eval the output of this container:'
-echo '#   eval "$(docker run cisagov/gophish-tools)"'
-echo '# '
-echo '# Environment variable:'
-echo '# GOPHISH_TOOLS_IMAGE, defaults to "cisagov/gophish-tools" if not set'
-echo '# '
-echo '################################################################################'
+echo ################################################################################
+echo # The following output is used to setup aliases to containerized commands.
+echo # To apply these changes in a shell, eval the output of this container:
+echo #   eval "$(docker run cisagov/gophish-tools)"
+echo #
+echo # Environment variable:
+echo # GOPHISH_TOOLS_IMAGE, defaults to "cisagov/gophish-tools" if not set
+echo #
+echo ################################################################################
 echo
 
-cd /usr/local/bin
+cd /usr/local/bin || exit
 
 # Create output that can be eval'd to create aliases for the various
 # commands in gophish-tools
-for f in pca-*
-do
+for f in pca-*; do
   echo alias $f=\"docker run -it --network host --rm --volume \\\`pwd\\\`:/home/cisa \\\"\\\${GOPHISH_TOOLS_IMAGE:-cisagov/gophish-tools}\\\" $f\"
 done
 
-for f in gophish-*
-do
+for f in gophish-*; do
   echo alias $f=\"docker run -it --network host --rm --volume \\\`pwd\\\`:/home/cisa \\\"\\\${GOPHISH_TOOLS_IMAGE:-cisagov/gophish-tools}\\\" $f\"
 done
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request makes a script executable again, fixing a bug introduced in #148.

## 💭 Motivation and context ##

[cisagov/pca-gophish-composition](https://github.com/cisagov/pca-gophish-composition) cannot pass its tests without this change.

Note that I invested very little effort into resolving the `shellcheck` errors in the script.  This is because as soon as cisagov/pca-gophish-composition#62 is merged I intend to remove cisagov/gophish-tools from it.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release.
