### PR TITLE
Return the parsed Click instance from Click.parse

### DIFF
--- a/src/_version.py
+++ b/src/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this project."""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -278,6 +278,7 @@ class Click(Model):
         for key, val in json.items():
             if key in cls._valid_properties:
                 setattr(click, key, val)
+        return click
 
     def __getitem__(self, item):
         """Get item by attribute name."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -302,6 +302,30 @@ def email_target_json():
 
 
 @pytest.fixture
+def click_json():
+    """Return a Click JSON."""
+    return json.loads("""{
+        "message": "Clicked Link",
+        "user": "john.doe@domain.test",
+        "source_ip": "10.0.0.1",
+        "time": "01/01/2025 13:00",
+        "application": "NA"
+    }""")
+
+
+@pytest.fixture
+def click_object():
+    """Return a single Click object."""
+    return Click(
+        message="Clicked Link",
+        user="john.doe@domain.test",
+        source_ip="10.0.0.1",
+        time="01/01/2025 13:00",
+        application="NA",
+    )
+
+
+@pytest.fixture
 def multiple_click_object():
     """Return a list of clicks to match the correct number of unique users."""
     clicks = []

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,16 @@
 """Test for Models."""
 
 # cisagov Libraries
-from models.models import SMTP, Assessment, Campaign, Group, Page, Target, Template
+from models.models import (
+    SMTP,
+    Assessment,
+    Campaign,
+    Click,
+    Group,
+    Page,
+    Target,
+    Template,
+)
 
 
 class TestParse:
@@ -36,3 +45,7 @@ class TestParse:
         assert (
             assessment_object.as_dict() == Assessment.parse(assessment_json).as_dict()
         )
+
+    def test_click_parse(self, click_object, click_json):
+        """Test parsing of click JSON."""
+        assert click_object.as_dict() == Click.parse(click_json).as_dict()


### PR DESCRIPTION
## 🗣 Description ##

`Click.parse()` builds a `Click` object from the JSON but never returns it, so it hands back `None`. Calling `.as_dict()` (or indexing) on that result raises an `AttributeError`. Every other model's `parse()` returns its instance, so this looks like a missed return rather than intended behavior. This adds the one-line `return click`.

## 💭 Motivation and context ##

The other models all have a parse round-trip test, but `Click` didn't, so the missing return slipped through. I added a matching `test_click_parse` (plus the `click_json`/`click_object` fixtures) that follows the same pattern as the existing model tests.

## 🧪 Testing ##

The new test fails on the current code (`AttributeError: 'NoneType' object has no attribute 'as_dict'`) and passes with the fix. The full test suite is green locally.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal.
- [x] I have read the CONTRIBUTING document.
- [x] These code changes follow cisagov code standards.